### PR TITLE
Fix multiple switch cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,12 +95,14 @@ const replace = (searchStr, replaceWith, options = {}) => {
         switch (typeof replaceWith) {
             case 'string':
                 transform.push(replaceStr);
+                break;
             case 'function':
                 const returnedStr = await replaceWith(matches);
                 if (typeof returnedStr !== 'string') {
                     throw new TypeError("Replace function did not return a string or a promise resolving a string.");
                 }
                 transform.push(returnedStr);
+                break;
             case 'object':
                 if (replaceWith instanceof Promise) {
                     replaceStr = await replaceWith;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "stream-replace-string",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-replace-string",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Replaces strings in a stream.",
   "main": "./dist/cjs/index.cjs",
   "types": "./index.d.ts",


### PR DESCRIPTION
In the `switch`, there was a bug when two of the `case`s didn't have a `break` after them. This caused problems.